### PR TITLE
Fix usage of custom databases in InteractionPrograms

### DIFF
--- a/R/interaction_programs.R
+++ b/R/interaction_programs.R
@@ -43,7 +43,7 @@ InteractionPrograms <- function(object, assay = "SCT", slot = "data",
     recepts <- recepts
     lit.put <- data.frame(pair.name = paste(ligands,recepts,sep="_"), source_genesymbol = ligands, target_genesymbol = recepts)
   }
-  if((!is.null(ligands) | !is.null(recepts)) & database != "custom") {
+  else if((!is.null(ligands) | !is.null(recepts)) & database != "custom") {
     stop("To use custom ligand or receptor lists, set database = 'custom'")
   }
   else {


### PR DESCRIPTION
Hello,

There appears to be an issue in InteractionPrograms where the custom database gets overwritten because of a missing `else if` statement. I have fixed it in this pull request.