### PR TITLE
Made fixes to allow for using AssembleInteractionGraphs with by = "weighted"

### DIFF
--- a/R/beta_testing.R
+++ b/R/beta_testing.R
@@ -80,10 +80,12 @@ PrioritizeLigands <- function(seu, gene_rankings = NULL, min.pct = 0.025, assay 
 #' @export
 #'
 #' @examples
-AssembleInteractionGraphs <- function(seu, by = "weighted", split.by = "time.orig") {
+AssembleInteractionGraphs <- function(seu, by = "weighted", split.by = "time.orig", nichenet_results = NULL, ...) {
   seu_split <- SplitObject(seu, split.by = split.by)
   if(by=="weighted") {
-    seu_split <- pblapply(seu_split, BuildWeightedInteraction)
+    seu_split <- pblapply(seu_split, function(x) {
+      BuildWeightedInteraction(x, nichenet_results, ...)
+     })
     interaction_graphs <- pblapply(seu_split, function(x) {
       p <- as.matrix(x@graphs$weighted_interaction)
       merge_ids <- seu$bins
@@ -100,7 +102,9 @@ AssembleInteractionGraphs <- function(seu, by = "weighted", split.by = "time.ori
     })
   }
   if(by=="prior") {
-    seu_split <- pblapply(seu_split, BuildPriorInteraction)
+    seu_split <- pblapply(seu_split, function(x) {
+      BuildPriorInteraction(x, ...)
+    })
     interaction_graphs <- pblapply(seu_split, function(x) {
       p <- as.matrix(x@graphs$prior_interaction)
       merge_ids <- seu$bins

--- a/R/binning.R
+++ b/R/binning.R
@@ -353,7 +353,7 @@ BinDatasets <- function(seu, split.by = "time.orig", dims = 1:50,
                                                                        sigtest_cell_types = sigtest_cell_types))
         return(sum(random_distribution>0.05)<5)
       }))
-      browser()
+      #browser()
       names(bin_p) <- unique(seu_oi$bins)
 
       anno.overlap <- t(reshape2::dcast(as.data.frame(table(as.character(seu_oi$bins),

--- a/R/rank_edges.R
+++ b/R/rank_edges.R
@@ -180,10 +180,10 @@ RankLigandTargets <- function(seu, signature_matrix, potential_ligands = NULL,
     tm[dsp==0] <- 0
     colnames(tm) <- colnames(dsp)
     rownames(tm) <- rownames(dsp)
+    if(species != "human") {
+      rownames(tm) <- nichenetr::convert_human_to_mouse_symbols(rownames(tm))
+    }
     return(tm)
   })
-  if(species != "human") {
-    rownames(tm) <- nichenetr::convert_human_to_mouse_symbols(rownames(tm))
-  }
-  return(tm)
+  return(ltl)
 }

--- a/R/rank_edges.R
+++ b/R/rank_edges.R
@@ -166,6 +166,7 @@ RankLigandTargets <- function(seu, signature_matrix, potential_ligands = NULL,
   }
   shared_targets <- intersect(rownames(ligand_target_matrix),colnames(dsp))
   shared_targets <- shared_targets[shared_targets %in% beg]
+  dsp <- dsp[,shared_targets]
   ltm <- ligand_target_matrix[shared_targets,]
   message("Calculating ligand-target links")
   ltl <- pblapply(seq_along(1:length(potential_ligands)), function(x) {
@@ -175,7 +176,7 @@ RankLigandTargets <- function(seu, signature_matrix, potential_ligands = NULL,
       head(ntargets) %>% min()
     ltm_vec[ltm_vec<top_n_score] <- 0
     ltm_vec <- ltm_vec[shared_targets]
-    tm <- matrix(rep(ltm_vec,ncol(dsp)), ncol = ncol(dsp))
+    tm <- matrix(rep(ltm_vec,nrow(dsp)), ncol = ncol(dsp))
     tm[dsp==0] <- 0
     colnames(tm) <- colnames(dsp)
     rownames(tm) <- rownames(dsp)
@@ -186,8 +187,3 @@ RankLigandTargets <- function(seu, signature_matrix, potential_ligands = NULL,
   }
   return(tm)
 }
-
-
-
-
-


### PR DESCRIPTION
When trying to use by="weighted" there are several issues preventing me from getting AssembleInteractionGraphs to run without crashing. The first change I made was to `RankLigandTargets` as it would often have dimension mismatches that would lead to crashes. 

I also had to adjust AssembleInteractionGraphs to allow for additional arguments to be passed to it. Most notable, nichenet_results as it is a required argument for BuildWeightedInteraction

Feel free to correct me if there are issues with the changes.